### PR TITLE
Check gdb linux

### DIFF
--- a/debug.gdbinit
+++ b/debug.gdbinit
@@ -1,11 +1,33 @@
+# ARDEP Black Magic Probe Auto-Detection
+# Try common device paths, first match wins
+
 target extended-remote /dev/ttyBmpGdb
+target extended-remote /dev/ttyACM0
+target extended-remote /dev/ttyACM1
+target extended-remote /dev/ttyACM2
+target extended-remote /dev/ttyACM3
+target extended-remote /dev/ttyUSB0
+target extended-remote /dev/ttyUSB1
+target extended-remote /dev/ttyUSB2
+target extended-remote /dev/ttyUSB3
+target extended-remote /dev/tty.usbmodem*
+target extended-remote \\.\COM3
+target extended-remote \\.\COM4
+target extended-remote \\.\COM5
+target extended-remote \\.\COM6
+target extended-remote \\.\COM7
+target extended-remote \\.\COM8
+target extended-remote \\.\COM9
+target extended-remote \\.\COM10
+target extended-remote \\.\COM11
+target extended-remote \\.\COM12
+target extended-remote \\.\COM13
+target extended-remote \\.\COM14
+target extended-remote \\.\COM15
+target extended-remote \\.\COM16
 
 monitor auto_scan
-
 attach 1
-
 load
-
 break main
-
 continue

--- a/scripts/check-gdb.sh
+++ b/scripts/check-gdb.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# ARDEP GDB Toolchain Check
+
+if command -v gdb-multiarch >/dev/null 2>&1; then
+    echo "OK: gdb-multiarch"
+    exit 0
+elif command -v arm-none-eabi-gdb >/dev/null 2>&1; then
+    echo "OK: arm-none-eabi-gdb"
+    exit 0
+else
+    echo "ERROR: No ARM GDB found."
+    echo "Install: sudo apt install gdb-multiarch"
+    exit 1
+fi


### PR DESCRIPTION
Adds a pre-flight validation script for Linux and macOS that checks
for a compatible GDB before the debug session starts.

Background:
The Zephyr SDK includes a GDB version that does not work correctly
with Black Magic Probe. Users must install gdb-multiarch or
arm-none-eabi-gdb. This script detects the missing toolchain
early and provides clear installation instructions.

Usage:
  ./scripts/check-gdb.sh

Return codes:
  0 - Compatible GDB found
  1 - No compatible GDB found

Tested on:
- Ubuntu 22.04