### PR TITLE
feat(toolchain): add GDB validation script for Linux/macOS

### DIFF
--- a/scripts/check-gdb.sh
+++ b/scripts/check-gdb.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# ARDEP GDB Toolchain Check
+
+if command -v gdb-multiarch >/dev/null 2>&1; then
+    echo "OK: gdb-multiarch"
+    exit 0
+elif command -v arm-none-eabi-gdb >/dev/null 2>&1; then
+    echo "OK: arm-none-eabi-gdb"
+    exit 0
+else
+    echo "ERROR: No ARM GDB found."
+    echo "Install: sudo apt install gdb-multiarch"
+    exit 1
+fi


### PR DESCRIPTION
Adds a pre-flight validation script for Linux and macOS that checks
for a compatible GDB before the debug session starts.

Background:
The Zephyr SDK includes a GDB version that does not work correctly
with Black Magic Probe. Users must install gdb-multiarch or
arm-none-eabi-gdb. This script detects the missing toolchain
early and provides clear installation instructions.

Usage:
  ./scripts/check-gdb.sh

Return codes:
  0 - Compatible GDB found
  1 - No compatible GDB found

Tested on:
- Ubuntu 22.04