### PR TITLE
feat(toolchain): add GDB validation script for Windows

### DIFF
--- a/scripts/check-gdb.bat
+++ b/scripts/check-gdb.bat
@@ -1,0 +1,12 @@
+@echo off
+REM ARDEP GDB Toolchain Check
+
+where arm-none-eabi-gdb >nul 2>nul
+if %errorlevel% equ 0 (
+    echo OK: arm-none-eabi-gdb
+    exit /b 0
+)
+
+echo ERROR: No ARM GDB found.
+echo Install ARM GCC toolchain from developer.arm.com
+exit /b 1


### PR DESCRIPTION
Adds a pre-flight validation script for Windows that checks for a
compatible GDB before the debug session starts.

Background:
The Zephyr SDK includes a GDB version that does not work correctly
with Black Magic Probe. Windows users must install the ARM GCC
toolchain. This script detects the missing toolchain early and
provides clear installation instructions.

Usage:
  scripts\check-gdb.bat

Return codes:
  0 - Compatible GDB found
  1 - No compatible GDB found

Tested on:
- Windows 11