### PR TITLE
feat(toolchain): add Black Magic Probe detection for Linux/macOS

### DIFF
--- a/scripts/check-bmp.sh
+++ b/scripts/check-bmp.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# ARDEP Black Magic Probe Detection
+
+for dev in /dev/ttyBmpGdb /dev/ttyACM0 /dev/ttyACM1 /dev/ttyACM2 /dev/ttyACM3 /dev/ttyUSB0 /dev/ttyUSB1 /dev/ttyUSB2 /dev/ttyUSB3 /dev/tty.usbmodem*; do
+    if [ -e "$dev" ]; then
+        echo "OK: BMP at $dev"
+        exit 0
+    fi
+done
+
+echo "ERROR: No Black Magic Probe detected."
+echo "Check USB connection and permissions."
+exit 1


### PR DESCRIPTION
Adds a pre-flight detection script for Linux and macOS that checks
for a connected Black Magic Probe before the debug session starts.

Background:
Users often attempt to debug before plugging in the BMP or without
proper permissions. This script detects the probe early and
provides clear troubleshooting steps.

Usage:
  ./scripts/check-bmp.sh

Return codes:
  0 - Probe found
  1 - No probe detected

Tested on:
- Ubuntu 22.04