### PR TITLE
doc: fix Link Control SID in UDS supported services table

### DIFF
--- a/lib/uds/README.rst
+++ b/lib/uds/README.rst
@@ -71,7 +71,7 @@ The following diagnostic services are currently implemented:
     * - Control DTC Settings
       - ``0x85``
     * - Link Control
-      - ``0x86``
+      - ``0x87``
 
 Getting Started
 ***************


### PR DESCRIPTION
Link Control is SID 0x87 per ISO 14229. The supported-services table listed 0x86, which is `ResponseOnEvent`. Corrected to 0x87 to match the other references in this file and `lib/uds/ecu_reset.c`.

Small fix mentioned in #50 